### PR TITLE
Replacing the use of absolute path with cwd.

### DIFF
--- a/finetune/PyTorch/notebooks/BERT_Eval_GLUE.ipynb
+++ b/finetune/PyTorch/notebooks/BERT_Eval_GLUE.ipynb
@@ -121,8 +121,8 @@
    "outputs": [],
    "source": [
     "import os\n",
-    "project_root = os.path.dirname((os.path.abspath('../../')))\n",
-    "#print(project_root)"
+    "import os.path as path\n",
+    "project_root = path.abspath(path.join(os.getcwd(),\"../../../\"))"
    ]
   },
   {
@@ -288,7 +288,7 @@
     "run_user_managed.environment.python.user_managed_dependencies = True\n",
     "\n",
     "# Define custom Docker image info\n",
-    "image_name = 'bing/bertnew:0.0.4'\n",
+    "image_name = 'bing/bertlite:0.0.6'\n",
     "\n",
     "image_registry_details = ContainerRegistry()\n",
     "image_registry_details.address = \"\"\n",


### PR DESCRIPTION
The current method of getting the project root makes use of absolute path which results in some path inconsistencies.