### PR TITLE
Refactor and fix splitting to shards

### DIFF
--- a/pretrain/PyTorch/dataprep/split_data_into_files.py
+++ b/pretrain/PyTorch/dataprep/split_data_into_files.py
@@ -18,15 +18,14 @@ with open(input_file, encoding="UTF-8") as ifile:
     line_counter = 0
     shard_index = 0
     ofile = open(f"{output_file}{shard_index}.txt", "w", encoding="UTF-8")  # Open the first file
-    for line in tqdm(ifile):
-        # We take whole documents and write at least shard_size lines into a file
-        if line_counter < shard_size or (line_counter >= shard_size and line != doc_seperator):
-            ofile.write(line)
+    # Output files should not have doc_separator at the end of the file, but we accept input ending with doc_separator
+    for iline_counter, line in tqdm(enumerate(ifile, start=1)):
+        if line != doc_seperator or line_counter < shard_size:
             line_counter += 1
-        else:
+            ofile.write(line)
+        elif iline_counter < ifile_lines:
             line_counter = 0
             shard_index += 1
             ofile.close()
             ofile = open(f"{output_file}{shard_index}.txt", "w", encoding="UTF-8")
-            ofile.write(line)  # Do not forget to write this line too!
     ofile.close()  # Close the lastfile

--- a/pretrain/PyTorch/dataprep/split_data_into_files.py
+++ b/pretrain/PyTorch/dataprep/split_data_into_files.py
@@ -15,16 +15,18 @@ print("Input file contains", ifile_lines, "lines.")
 shard_size = ifile_lines // total_partitions
 
 with open(input_file, encoding="UTF-8") as ifile:
-    line_counter = 0
+    shard_line_counter = 0
     shard_index = 0
     ofile = open(f"{output_file}{shard_index}.txt", "w", encoding="UTF-8")  # Open the first file
     # Output files should not have doc_separator at the end of the file, but we accept input ending with doc_separator
     for iline_counter, line in tqdm(enumerate(ifile, start=1)):
-        if line != doc_seperator or line_counter < shard_size:
-            line_counter += 1
+        if line != doc_seperator or shard_line_counter < shard_size:
+            shard_line_counter += 1
             ofile.write(line)
+        # Prevent opening an empty output file or writing a doc_sep
+        # when the iteration has reached the end of the input file (iline_counter == ifile_lines)
         elif iline_counter < ifile_lines:
-            line_counter = 0
+            shard_line_counter = 0
             shard_index += 1
             ofile.close()
             ofile = open(f"{output_file}{shard_index}.txt", "w", encoding="UTF-8")

--- a/pretrain/PyTorch/dataprep/split_data_into_files.py
+++ b/pretrain/PyTorch/dataprep/split_data_into_files.py
@@ -1,41 +1,32 @@
-import os
 from tqdm import tqdm
 
-input_file = 'wikipedia.segmented.nltk.txt'
-output_file = './data_shards/wikipedia.segmented.part.'
+input_file = "wikipedia.segmented.nltk.txt"
+output_file = "./data_shards/wikipedia.segmented.part."
 
 doc_seperator = "\n"
-
-line_buffer = []
 total_partitions = 100  # Mostly will create 1 extra partition
 # shard_size = 396000 # Approximate, will split at next article break
-line_counter = 0
-shard_index = 0
 
-ifile_lines = 0
-with open(input_file) as ifile:
-    for i, line in tqdm(enumerate(ifile)):
-        ifile_lines += 1
+with open(input_file, encoding="UTF-8") as ifile:
+    ifile_lines = sum(1 for _ in tqdm(ifile))
 
 print("Input file contains", ifile_lines, "lines.")
 
 shard_size = ifile_lines // total_partitions
 
-iline_counter = 1
-with open(input_file) as ifile:
-    for i, line in tqdm(enumerate(ifile)):
-        if line_counter < shard_size and iline_counter < ifile_lines:
-            line_buffer.append(line)
+with open(input_file, encoding="UTF-8") as ifile:
+    line_counter = 0
+    shard_index = 0
+    ofile = open(f"{output_file}{shard_index}.txt", "w", encoding="UTF-8")  # Open the first file
+    for line in tqdm(ifile):
+        # We take whole documents and write at least shard_size lines into a file
+        if line_counter < shard_size or (line_counter >= shard_size and line != doc_seperator):
+            ofile.write(line)
             line_counter += 1
-            iline_counter += 1
-        elif line_counter >= shard_size and line != "\n" and iline_counter < ifile_lines:
-            line_buffer.append(line)
-            line_counter += 1
-            iline_counter += 1
         else:
-            with open(output_file + str(shard_index) + ".txt", "w") as ofile:
-                for oline in line_buffer:
-                    ofile.write(oline)
-                line_buffer = []
-                line_counter = 0
-                shard_index += 1
+            line_counter = 0
+            shard_index += 1
+            ofile.close()
+            ofile = open(f"{output_file}{shard_index}.txt", "w", encoding="UTF-8")
+            ofile.write(line)  # Do not forget to write this line too!
+    ofile.close()  # Close the lastfile


### PR DESCRIPTION
There were multiple problems with the previous implementation:

1. The document separator definition was not used at all
2. __Major bug__: The last shard was not written (just buffered) when there was no empty line at the end of the input file.
3. No encoding were given to files
4. There were a few unnecessary operations
